### PR TITLE
Add ingestion utilities

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,25 @@
+# Add labels to PR based on the paths that are modified in the PR
+ingestion:
+  - opendiscourse/ingestion/**
+
+documentation:
+  - "*.md"
+  - docs/**
+
+tests:
+  - tests/**
+
+database:
+  - "*.sql"
+  - src/database/**
+
+scripts:
+  - scripts/**
+
+dependencies:
+  - requirements/**
+  - pyproject.toml
+  - setup.py
+
+github-actions:
+  - .github/**

--- a/DIFF_2025-06-16_01-41-33.md
+++ b/DIFF_2025-06-16_01-41-33.md
@@ -1,0 +1,2 @@
+- Created ingestion package with document_ingestion.py, govinfo_templates.py, and __init__.py
+- Updated tests/unit/test_entity_extractor.py to adjust sys.path and import path

--- a/RECOMMENDATIONS_2025-06-16_01-41-33.md
+++ b/RECOMMENDATIONS_2025-06-16_01-41-33.md
@@ -1,0 +1,2 @@
+- Implement unit tests for new ingestion functions using temporary files and mocks
+- Add pdfminer.six and markdown parsing libraries to requirements for full functionality

--- a/opendiscourse/ingestion/document_ingestion.py
+++ b/opendiscourse/ingestion/document_ingestion.py
@@ -1,0 +1,153 @@
+"""Utility functions for ingesting various document types into the database."""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import requests
+from bs4 import BeautifulSoup
+from typing_extensions import TypedDict
+
+try:  # Optional dependencies
+    from pdfminer.high_level import extract_text as extract_pdf_text
+except Exception:  # pragma: no cover - optional dependency may be missing
+    extract_pdf_text = None
+
+try:
+    import whisper
+except Exception:  # pragma: no cover
+    whisper = None
+
+
+class DocumentMetadata(TypedDict, total=False):
+    """Metadata used when saving documents."""
+
+    title: str
+    source_url: str
+    source_id: str
+    source_type: str
+    source_date: str
+    source_collection: str
+    created_at: datetime
+    document_type: Optional[str]
+    type: Optional[str]
+
+
+def _get_db_connection():
+    """Create a database connection using environment variables."""
+    import psycopg2
+
+    return psycopg2.connect(
+        dbname=os.getenv("POSTGRES_DB"),
+        user=os.getenv("POSTGRES_USER"),
+        password=os.getenv("POSTGRES_PASSWORD"),
+        host=os.getenv("POSTGRES_HOST"),
+        port=os.getenv("POSTGRES_PORT"),
+    )
+
+
+def _save_document(content: str, metadata: DocumentMetadata) -> Optional[int]:
+    """Save document content and metadata to the database."""
+
+    try:
+        conn = _get_db_connection()
+    except Exception as exc:  # pragma: no cover - database may be unavailable
+        logging.error("Database connection failed: %s", exc)
+        return None
+
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO documents (
+                    title,
+                    content,
+                    source_url,
+                    source_id,
+                    source_type,
+                    source_date,
+                    source_collection,
+                    created_at,
+                    document_type
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                RETURNING id
+                """,
+                (
+                    metadata.get("title", "Untitled"),
+                    content,
+                    metadata.get("source_url", ""),
+                    metadata.get("source_id", ""),
+                    metadata.get("source_type", ""),
+                    metadata.get("source_date", ""),
+                    metadata.get("source_collection", ""),
+                    metadata.get("created_at", datetime.utcnow()),
+                    metadata.get("document_type"),
+                ),
+            )
+            doc_id = cur.fetchone()[0]
+            conn.commit()
+            return int(doc_id)
+    except Exception as exc:  # pragma: no cover - db errors
+        conn.rollback()
+        logging.error("Failed to save document: %s", exc)
+        return None
+    finally:
+        conn.close()
+
+
+def ingest_text(text: str, metadata: DocumentMetadata) -> Optional[int]:
+    """Ingest a plain text document."""
+
+    return _save_document(text, metadata)
+
+
+def ingest_markdown(path: str | Path, metadata: DocumentMetadata) -> Optional[int]:
+    """Ingest a Markdown file as plain text."""
+
+    content = Path(path).read_text(encoding="utf-8")
+    return _save_document(content, metadata)
+
+
+def ingest_pdf(path: str | Path, metadata: DocumentMetadata) -> Optional[int]:
+    """Ingest a PDF file using pdfminer if available."""
+
+    if extract_pdf_text is None:  # pragma: no cover - dependency missing
+        logging.error("pdfminer.six is not installed")
+        return None
+
+    content = extract_pdf_text(str(path))
+    return _save_document(content, metadata)
+
+
+def ingest_website(url: str, metadata: DocumentMetadata) -> Optional[int]:
+    """Download a webpage and ingest the text content."""
+
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+    text = soup.get_text(separator="\n")
+    return _save_document(text, metadata)
+
+
+def ingest_http_code(url: str, metadata: DocumentMetadata) -> Optional[int]:
+    """Ingest code from an HTTP endpoint."""
+
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    return _save_document(resp.text, metadata)
+
+
+def ingest_video(path: str | Path, metadata: DocumentMetadata) -> Optional[int]:
+    """Transcribe and ingest a video file using Whisper if available."""
+
+    if whisper is None:  # pragma: no cover - dependency missing
+        logging.error("whisper is not installed")
+        return None
+
+    model = whisper.load_model("base")
+    result = model.transcribe(str(path))
+    return _save_document(result.get("text", ""), metadata)

--- a/opendiscourse/ingestion/govinfo_templates.py
+++ b/opendiscourse/ingestion/govinfo_templates.py
@@ -1,0 +1,73 @@
+"""Templates for ingesting data from the GovInfo APIs and bulk data."""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
+from typing import Optional
+
+import requests
+
+from .document_ingestion import DocumentMetadata, _save_document
+
+logger = logging.getLogger(__name__)
+
+
+def ingest_govinfo_api(package_id: str) -> Optional[int]:
+    """Fetch a package from the GovInfo API and ingest it."""
+
+    api_key = os.getenv("GOVINFO_API_KEY")
+    if not api_key:
+        logger.error("GOVINFO_API_KEY not configured")
+        return None
+
+    base_url = "https://api.govinfo.gov/v1/package"
+    url = f"{base_url}/{package_id}?api_key={api_key}"
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+
+    text_link = data.get("textLink")
+    if not text_link:
+        logger.error("No textLink in package %s", package_id)
+        return None
+
+    text_resp = requests.get(text_link, timeout=30)
+    text_resp.raise_for_status()
+
+    metadata: DocumentMetadata = {
+        "title": data.get("title", "GovInfo Document"),
+        "source_url": text_link,
+        "source_id": package_id,
+        "source_type": "govinfo_api",
+        "source_date": data.get("dateIssued", ""),
+        "source_collection": data.get("collectionCode", ""),
+        "created_at": datetime.utcnow(),
+        "document_type": data.get("documentType"),
+    }
+
+    return _save_document(text_resp.text, metadata)
+
+
+def ingest_govinfo_bulkdata(
+    collection: str, year: int, file_name: str
+) -> Optional[int]:
+    """Download a bulk data file from GovInfo and ingest it."""
+
+    url = f"https://www.govinfo.gov/bulkdata/{collection}/{year}/{file_name}"
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+
+    metadata: DocumentMetadata = {
+        "title": file_name,
+        "source_url": url,
+        "source_id": file_name,
+        "source_type": "govinfo_bulkdata",
+        "source_date": str(year),
+        "source_collection": collection,
+        "created_at": datetime.utcnow(),
+        "document_type": None,
+    }
+
+    return _save_document(resp.text, metadata)

--- a/tests/unit/test_entity_extractor.py
+++ b/tests/unit/test_entity_extractor.py
@@ -1,10 +1,12 @@
 import sys
+from pathlib import Path
 
-sys.path.append("/home/cbwinslow/CascadeProjects/opendiscourse")
+# Ensure project root is on sys.path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import logging
 
-from entity_extractor import (
+from opendiscourse.entity_extractor import (
     extract_entities,
     save_entity,
     save_entity_mention,

--- a/tests/unit/test_entity_extractor.py
+++ b/tests/unit/test_entity_extractor.py
@@ -2,7 +2,7 @@ import sys
 from pathlib import Path
 
 # Ensure project root is on sys.path
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 import logging
 


### PR DESCRIPTION
## Summary
- add `ingestion` package with document ingestion helpers
- include govinfo API/bulkdata ingestion templates
- fix entity extractor test import path
- document changes in `DIFF_2025-06-16_01-41-33.md`
- add recommendations in `RECOMMENDATIONS_2025-06-16_01-41-33.md`

## Testing
- `black .`
- `ruff check --fix .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_684cfa88b510832aa1e5b0cf5b320c4e