### PR TITLE
Add PDF vector workflow

### DIFF
--- a/DIFF_20250621T115446Z.md
+++ b/DIFF_20250621T115446Z.md
@@ -1,0 +1,8 @@
+# Change Log
+
+## 2025-06-21 Semantic search workflow
+- Added `weaviate-client` and `pinecone-client` to Python requirements.
+- Extended `src/database/schema.sql` with tables `pdf_documents` and `pdf_document_translations`.
+- Created `scripts/semantic_vector_workflow.py` to ingest PDFs and store embeddings in Chroma, Pinecone, and Weaviate.
+- Documented the process in `opendiscourse-semantic-search.md`.
+

--- a/RECOMMENDATIONS_20250621T115446Z.md
+++ b/RECOMMENDATIONS_20250621T115446Z.md
@@ -1,0 +1,7 @@
+# Recommendations
+
+## 2025-06-21 Ideas
+- Implement real translation support using a dedicated model and store results in `pdf_document_translations`.
+- Add automated tests for `scripts/semantic_vector_workflow.py` to verify vector store writes.
+- Consider orchestrating the ingestion workflow via a task queue for large batches of PDFs.
+

--- a/opendiscourse-semantic-search.md
+++ b/opendiscourse-semantic-search.md
@@ -1,0 +1,16 @@
+# Semantic Search Workflow
+
+This document outlines how to ingest PDF documents and store their embeddings across multiple vector databases.
+
+## Workflow Steps
+1. **Parse PDF** using `pdfminer.six` to extract text.
+2. **Generate embeddings** with `sentence-transformers/all-MiniLM-L6-v2`.
+3. **Store embeddings** in:
+   - **Chroma** via `VectorDatabase` (local persistence).
+   - **Pinecone** index `pdf-docs`.
+   - **Weaviate** class `PDFDoc` with custom schema.
+4. **Translate text** (placeholder in `EmbeddingWorkflow.translate_document`), storing results in the `pdf_document_translations` table.
+5. **Query** any of the vector stores for semantic search.
+
+The `scripts/semantic_vector_workflow.py` script provides a minimal reference implementation.
+

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -31,3 +31,6 @@ python-dateutil==2.8.2
 pydantic==2.5.2
 aiohttp==3.10.11
 aiosqlite==0.19.0
+
+weaviate-client==4.5.4
+pinecone-client==3.2.2

--- a/scripts/semantic_vector_workflow.py
+++ b/scripts/semantic_vector_workflow.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Workflow for PDF ingestion and semantic search across Chroma, Pinecone, and Weaviate."""
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+import pinecone
+import weaviate
+from pdfminer.high_level import extract_text
+from dotenv import load_dotenv
+from sentence_transformers import SentenceTransformer
+
+from opendiscourse.services.vector_store import VectorDatabase
+
+load_dotenv()
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+@dataclass
+class PDFDocument:
+    """Simple representation of a PDF document."""
+
+    doc_id: int
+    title: str
+    content: str
+    metadata: Dict[str, Any]
+
+
+@dataclass
+class PDFTranslation:
+    """Translated text of a PDF document."""
+
+    doc_id: int
+    language: str
+    translated_text: str
+    summary: str | None = None
+
+
+class EmbeddingWorkflow:
+    """Generate embeddings and store them in multiple vector DBs."""
+
+    def __init__(self) -> None:
+        self.model = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
+        self.vector_db = VectorDatabase(collection_name="pdf_docs")
+        pinecone.init(api_key=os.getenv("PINECONE_API_KEY"), environment=os.getenv("PINECONE_ENVIRONMENT"))
+        self.pinecone_index = pinecone.Index("pdf-docs")
+        self.weaviate_client = weaviate.Client(url=os.getenv("WEAVIATE_URL", "http://localhost:8080"))
+        self._ensure_weaviate_schema()
+
+    def _ensure_weaviate_schema(self) -> None:
+        schema = {
+            "classes": [
+                {
+                    "class": "PDFDoc",
+                    "vectorizer": "none",
+                    "properties": [
+                        {"name": "doc_id", "dataType": ["int"], "description": "Document ID"},
+                        {"name": "title", "dataType": ["text"], "description": "Document title"},
+                        {"name": "content", "dataType": ["text"], "description": "Raw text"},
+                    ],
+                }
+            ]
+        }
+        existing = self.weaviate_client.schema.get()
+        if not any(cls["class"] == "PDFDoc" for cls in existing.get("classes", [])):
+            self.weaviate_client.schema.create(schema)
+
+    def _embed(self, text: str) -> List[float]:
+        return self.model.encode(text, convert_to_numpy=True).tolist()
+
+    def add_pdf(self, pdf_path: str, doc_id: int, title: str) -> None:
+        text = extract_text(pdf_path)
+        metadata = {"source_file": os.path.basename(pdf_path)}
+        document = PDFDocument(doc_id=doc_id, title=title, content=text, metadata=metadata)
+        self.vector_db.add_document(doc_id, text, metadata)
+        vector = self._embed(text)
+        self.pinecone_index.upsert([(str(doc_id), vector, {"title": title})])
+        self.weaviate_client.batch.add_data_object({"doc_id": doc_id, "title": title, "content": text}, "PDFDoc", vector)
+
+    def translate_document(self, document: PDFDocument, language: str = "en") -> PDFTranslation:
+        # Placeholder translation step, replace with real model or API
+        translated = document.content  # In practice call translation API
+        return PDFTranslation(doc_id=document.doc_id, language=language, translated_text=translated)
+
+
+if __name__ == "__main__":
+    workflow = EmbeddingWorkflow()
+    # Example usage: ingest sample.pdf with id 1
+    if os.path.exists("sample.pdf"):
+        workflow.add_pdf("sample.pdf", 1, "Sample PDF")
+        logger.info("PDF ingested into all vector stores")
+

--- a/src/database/schema.sql
+++ b/src/database/schema.sql
@@ -173,3 +173,23 @@ CREATE TABLE document_entities (
     sentiment_score DECIMAL(4,2),
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
+-- PDF Documents table
+CREATE TABLE pdf_documents (
+    id SERIAL PRIMARY KEY,
+    source_file TEXT NOT NULL,
+    title TEXT,
+    content TEXT,
+    metadata JSONB,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- PDF Translations table
+CREATE TABLE pdf_document_translations (
+    id SERIAL PRIMARY KEY,
+    pdf_document_id INTEGER REFERENCES pdf_documents(id),
+    language VARCHAR(10) NOT NULL,
+    translated_text TEXT NOT NULL,
+    summary TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- add weaviate and pinecone clients to requirements
- extend database schema with PDF document and translation tables
- implement `scripts/semantic_vector_workflow.py` for PDF ingestion
- document the new process in `opendiscourse-semantic-search.md`
- record change log and recommendations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569ccc8750832aa74d1bd463eb6a30

## Summary by Sourcery

Implement a new end-to-end PDF ingestion and semantic search workflow by extending the database schema, updating dependencies, providing a reference script, and documenting the process.

New Features:
- Add PDF semantic vector ingestion workflow script for Chroma, Pinecone, and Weaviate
- Add Weaviate and Pinecone clients to project dependencies

Enhancements:
- Extend database schema with pdf_documents and pdf_document_translations tables

Documentation:
- Document the PDF semantic search workflow in opendiscourse-semantic-search.md

Chores:
- Add a change log and recommendations for future improvements