### PR TITLE
test: run bulk integration checks against PostGIS

### DIFF
--- a/tests/test_census_bulk_integration.py
+++ b/tests/test_census_bulk_integration.py
@@ -1,21 +1,21 @@
-"""Opt-in database smoke tests for bulk stage/load idempotence.
-
-Run only against a disposable database:
-``OPENDISCOURSE_TEST_DATABASE_URL=... uv run --extra ingest python -m unittest tests.test_census_bulk_integration``.
-"""
+"""PostGIS integration coverage for bulk stage/load idempotence."""
 
 from __future__ import annotations
 
 import csv
+import os
 import unittest
+from collections.abc import Iterator
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 from zipfile import ZipFile
 
+import pytest
+
 from opendiscourse_research.catalog import sync_inventory
 from opendiscourse_research.config import settings
-from opendiscourse_research.db import apply_migrations, connect
+from opendiscourse_research.db import _engine, apply_migrations, connect
 from opendiscourse_research.ingestion.acs_load import load_acs_bulk, stage_acs_bulk
 from opendiscourse_research.ingestion.bulk import ArtifactSpec, register_local
 from opendiscourse_research.ingestion.cbp_load import load_cbp, stage_cbp
@@ -24,26 +24,45 @@ from opendiscourse_research.ingestion.fec_bulk import stage_family
 from opendiscourse_research.ingestion.pep_load import load_pep, stage_pep
 from opendiscourse_research.ingestion.tiger_load import load_tiger, stage_tiger
 
-TEST_DATABASE_URL = __import__("os").environ.get("OPENDISCOURSE_TEST_DATABASE_URL")
+def _psycopg_url(url: str) -> str:
+    """Normalize Testcontainers' SQLAlchemy URL for the psycopg connection factory."""
+    return url.replace("postgresql+psycopg2://", "postgresql://", 1)
 
 
-@unittest.skipUnless(
-    TEST_DATABASE_URL,
-    "Set OPENDISCOURSE_TEST_DATABASE_URL to run database integration tests",
-)
-class TestBulkDatabaseIntegration(unittest.TestCase):
-    """Use generated source artifacts only; never call upstream providers in tests."""
-
-    @classmethod
-    def setUpClass(cls) -> None:
-        cls._original_url = settings.database_url
-        settings.database_url = str(TEST_DATABASE_URL)
+@pytest.fixture(scope="module", autouse=True)
+def bulk_database() -> Iterator[None]:
+    """Provide CI's service or a disposable PostGIS database for bulk tests."""
+    original_url = settings.database_url
+    external_url = os.environ.get("OPENDISCOURSE_TEST_DATABASE_URL")
+    if external_url:
+        settings.database_url = external_url
         apply_migrations()
         sync_inventory()
+        try:
+            yield
+        finally:
+            settings.database_url = original_url
+        return
 
-    @classmethod
-    def tearDownClass(cls) -> None:
-        settings.database_url = cls._original_url
+    postgres = pytest.importorskip("testcontainers.postgres")
+    with postgres.PostgresContainer(
+        "postgis/postgis:17-3.5",
+        username="test",
+        password="test",
+        dbname="test",
+    ) as container:
+        settings.database_url = _psycopg_url(container.get_connection_url())
+        apply_migrations()
+        sync_inventory()
+        try:
+            yield
+        finally:
+            settings.database_url = original_url
+            _engine.cache_clear()
+
+
+class TestBulkDatabaseIntegration(unittest.TestCase):
+    """Use generated source artifacts only; never call upstream providers in tests."""
 
     def setUp(self) -> None:
         self.temp = TemporaryDirectory()

--- a/tests/test_census_bulk_integration.py
+++ b/tests/test_census_bulk_integration.py
@@ -24,6 +24,10 @@ from opendiscourse_research.ingestion.fec_bulk import stage_family
 from opendiscourse_research.ingestion.pep_load import load_pep, stage_pep
 from opendiscourse_research.ingestion.tiger_load import load_tiger, stage_tiger
 
+
+_BULK_DATABASE_READY = False
+
+
 def _psycopg_url(url: str) -> str:
     """Normalize Testcontainers' SQLAlchemy URL for the psycopg connection factory."""
     return url.replace("postgresql+psycopg2://", "postgresql://", 1)
@@ -32,15 +36,19 @@ def _psycopg_url(url: str) -> str:
 @pytest.fixture(scope="module", autouse=True)
 def bulk_database() -> Iterator[None]:
     """Provide CI's service or a disposable PostGIS database for bulk tests."""
+    global _BULK_DATABASE_READY
     original_url = settings.database_url
     external_url = os.environ.get("OPENDISCOURSE_TEST_DATABASE_URL")
     if external_url:
-        settings.database_url = external_url
-        apply_migrations()
-        sync_inventory()
         try:
+            settings.database_url = external_url
+            apply_migrations()
+            sync_inventory()
+            _BULK_DATABASE_READY = True
             yield
         finally:
+            _BULK_DATABASE_READY = False
+            _engine.cache_clear()
             settings.database_url = original_url
         return
 
@@ -51,18 +59,26 @@ def bulk_database() -> Iterator[None]:
         password="test",
         dbname="test",
     ) as container:
-        settings.database_url = _psycopg_url(container.get_connection_url())
-        apply_migrations()
-        sync_inventory()
         try:
+            settings.database_url = _psycopg_url(container.get_connection_url())
+            apply_migrations()
+            sync_inventory()
+            _BULK_DATABASE_READY = True
             yield
         finally:
+            _BULK_DATABASE_READY = False
             settings.database_url = original_url
             _engine.cache_clear()
 
 
 class TestBulkDatabaseIntegration(unittest.TestCase):
     """Use generated source artifacts only; never call upstream providers in tests."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Prevent unittest from running mutating database tests without pytest's fixture."""
+        if not _BULK_DATABASE_READY:
+            raise unittest.SkipTest("Run this module with pytest so bulk_database is active")
 
     def setUp(self) -> None:
         self.temp = TemporaryDirectory()


### PR DESCRIPTION
## **User description**
Summary: replace the opt-in environment-variable gate on bulk integration tests with the established CI-service-or-disposable-Testcontainers PostGIS fixture. The seven bulk tests now run in the standard suite.

Validation: uv run --locked --extra ingest --extra spatial pytest -q tests/test_census_bulk_integration.py (7 passed); uv run alembic check; uv run --locked --extra ingest --extra spatial pytest -q; git diff --check.


___

## **CodeAnt-AI Description**
Run bulk integration checks against an available PostGIS database

### What Changed
- Bulk database integration tests now run as part of the standard test suite instead of requiring an opt-in environment variable
- Tests use the CI database when configured, or automatically start a disposable PostGIS database when it is not
- Database setup and cleanup are handled automatically for reliable isolated test runs

### Impact
`✅ Bulk integration coverage runs in standard CI`
`✅ Fewer skipped database tests`
`✅ Isolated PostGIS test environments`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
