### PR TITLE
feat: add safe research measurement exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ research-db bootstrap openstates-dump --year 2026 --month 7
 # Treasury's full published nominal curve for a calendar year; no key required.
 research-db bootstrap treasury-curve --year 2025
 
+# Export a reviewed canonical research surface. CSV works in a base install;
+# Parquet requires `uv sync --extra analytics`.
+research-db export measurements --output ./exports/measurements.csv
+
 # Curated priority-one FRED macro, labor, rates, yield, index, commodity, and FX series.
 # Requires FRED_API_KEY in .env.
 research-db bootstrap fred-core

--- a/src/opendiscourse_research/cli.py
+++ b/src/opendiscourse_research/cli.py
@@ -33,6 +33,7 @@ from .censushealth import census_health
 from .congresshealth import congressional_health, recover_stale_congressional_runs
 from .contracts import load_contracts, validate_contracts
 from .db import apply_migrations
+from .exports import available_exports, export_relation
 from .feedback import (
     progress as render_progress,
 )
@@ -117,6 +118,20 @@ app.add_typer(bootstrap_app, name="bootstrap", hidden=True)
 # Compatibility entry point for earlier scripts. The normal operator surface is
 # intentionally just `browse`, `sync`, and `status`.
 app.add_typer(catalog_app, name="catalog", hidden=True)
+
+
+@app.command("export")
+def export(
+    relation: str = typer.Argument(..., help=f"Named relation: {', '.join(available_exports())}"),
+    output: Path = typer.Option(..., "--output", "-o", help="New destination file."),
+    format_: str = typer.Option("csv", "--format", help="csv, jsonl, or parquet."),
+) -> None:
+    """Export one approved research relation without accepting arbitrary SQL."""
+    try:
+        count = export_relation(relation, output, format_)
+    except (FileExistsError, RuntimeError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from None
+    typer.echo(f"Exported {count} {relation} rows to {output}.")
 
 
 @app.command("init-db")

--- a/src/opendiscourse_research/exports.py
+++ b/src/opendiscourse_research/exports.py
@@ -71,11 +71,25 @@ def export_relation(name: str, output: Path, format_: str) -> int:
     return len(rows)
 
 
-def _json_default(value: Any) -> Any:
-    """Preserve numeric precision for Decimal columns; fall back to text for the rest."""
+def _json_scalar(key: str, value: Any) -> str:
+    """Render one field as a JSON token, keeping Decimal precision exact.
+
+    Routing Decimal through ``float`` would round it; formatting it as fixed-point
+    text and splicing that text in directly preserves the database's exact scale
+    (``0.10`` stays ``0.10``) without pulling in a JSON library that special-cases
+    ``Decimal``.
+    """
     if isinstance(value, Decimal):
-        return float(value)
-    return str(value)
+        if not value.is_finite():
+            raise ValueError(f"Cannot export non-finite value for {key!r}: {value}")
+        return format(value, "f")
+    return json.dumps(value, default=str)
+
+
+def _dumps_row(row: dict[str, Any]) -> str:
+    """Serialize one row as a compact JSON object with exact Decimal precision."""
+    fields = (f"{json.dumps(key)}: {_json_scalar(key, value)}" for key, value in sorted(row.items()))
+    return "{" + ", ".join(fields) + "}"
 
 
 def _atomic_write(
@@ -123,7 +137,7 @@ def _write(
 
         def write_jsonl(stream: Any) -> None:
             for row in materialized:
-                stream.write(json.dumps(row, default=_json_default, sort_keys=True) + "\n")
+                stream.write(_dumps_row(row) + "\n")
 
         _atomic_write(output, "w", write_jsonl)
         return

--- a/src/opendiscourse_research/exports.py
+++ b/src/opendiscourse_research/exports.py
@@ -1,0 +1,69 @@
+"""Safe, named research exports from canonical database relations."""
+
+from __future__ import annotations
+
+import csv
+import json
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from .db import connect
+from .feedback import spinner
+
+EXPORTS = {
+    "measurements": (
+        "SELECT measurement_id, dataset_id, field_id, geography_id, period_start, "
+        "period_end, vintage_date, value_numeric, value_text, unit, flags, "
+        "source_payload_id FROM fact.measurement "
+        "ORDER BY dataset_id, field_id, period_start, measurement_id"
+    ),
+}
+
+
+def available_exports() -> tuple[str, ...]:
+    """Return the stable names accepted by the researcher export API."""
+    return tuple(EXPORTS)
+
+
+def export_relation(name: str, output: Path, format_: str) -> int:
+    """Export one approved relation without accepting arbitrary SQL input."""
+    try:
+        statement = EXPORTS[name]
+    except KeyError as exc:
+        raise ValueError(f"Unknown export {name!r}; choose one of: {', '.join(EXPORTS)}") from exc
+    if output.exists():
+        raise FileExistsError(f"Refusing to overwrite existing export: {output}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with spinner(f"Exporting {name} as {format_}") as update:
+        with connect() as connection, connection.cursor() as cursor:
+            cursor.execute(statement)
+            rows = list(cursor.fetchall())
+        update(f"Writing {len(rows)} {name} rows")
+        _write(rows, output, format_)
+    return len(rows)
+
+
+def _write(rows: Iterable[dict[str, Any]], output: Path, format_: str) -> None:
+    """Write rows in a portable researcher format."""
+    materialized = list(rows)
+    if format_ == "csv":
+        fields = list(materialized[0]) if materialized else []
+        with output.open("x", newline="") as stream:
+            writer = csv.DictWriter(stream, fieldnames=fields)
+            writer.writeheader()
+            writer.writerows(materialized)
+        return
+    if format_ == "jsonl":
+        with output.open("x") as stream:
+            for row in materialized:
+                stream.write(json.dumps(row, default=str, sort_keys=True) + "\n")
+        return
+    if format_ == "parquet":
+        try:
+            import polars as pl
+        except ImportError as exc:
+            raise RuntimeError("Parquet export requires `uv sync --extra analytics`") from exc
+        pl.DataFrame(materialized).write_parquet(output)
+        return
+    raise ValueError("format must be one of: csv, jsonl, parquet")

--- a/src/opendiscourse_research/exports.py
+++ b/src/opendiscourse_research/exports.py
@@ -4,19 +4,41 @@ from __future__ import annotations
 
 import csv
 import json
-from collections.abc import Iterable
+import os
+import tempfile
+from collections.abc import Callable, Iterable, Sequence
+from decimal import Decimal
 from pathlib import Path
 from typing import Any
+
+import psycopg
 
 from .db import connect
 from .feedback import spinner
 
+_FORMATS = ("csv", "jsonl", "parquet")
+
+_MEASUREMENT_FIELDS = (
+    "measurement_id",
+    "dataset_id",
+    "field_id",
+    "geography_id",
+    "period_start",
+    "period_end",
+    "vintage_date",
+    "value_numeric",
+    "value_text",
+    "unit",
+    "margin_of_error",
+    "flags",
+    "source_payload_id",
+)
+
 EXPORTS = {
     "measurements": (
-        "SELECT measurement_id, dataset_id, field_id, geography_id, period_start, "
-        "period_end, vintage_date, value_numeric, value_text, unit, flags, "
-        "source_payload_id FROM fact.measurement "
-        "ORDER BY dataset_id, field_id, period_start, measurement_id"
+        _MEASUREMENT_FIELDS,
+        "SELECT " + ", ".join(_MEASUREMENT_FIELDS) + " FROM fact.measurement "
+        "ORDER BY dataset_id, field_id, period_start, measurement_id",
     ),
 }
 
@@ -28,42 +50,90 @@ def available_exports() -> tuple[str, ...]:
 
 def export_relation(name: str, output: Path, format_: str) -> int:
     """Export one approved relation without accepting arbitrary SQL input."""
+    if format_ not in _FORMATS:
+        raise ValueError(f"format must be one of: {', '.join(_FORMATS)}")
     try:
-        statement = EXPORTS[name]
+        fields, statement = EXPORTS[name]
     except KeyError as exc:
         raise ValueError(f"Unknown export {name!r}; choose one of: {', '.join(EXPORTS)}") from exc
     if output.exists():
         raise FileExistsError(f"Refusing to overwrite existing export: {output}")
     output.parent.mkdir(parents=True, exist_ok=True)
     with spinner(f"Exporting {name} as {format_}") as update:
-        with connect() as connection, connection.cursor() as cursor:
-            cursor.execute(statement)
-            rows = list(cursor.fetchall())
+        try:
+            with connect() as connection, connection.cursor() as cursor:
+                cursor.execute(statement)
+                rows = cursor.fetchall()
+        except psycopg.Error as exc:
+            raise RuntimeError(f"Export query failed: {exc}") from exc
         update(f"Writing {len(rows)} {name} rows")
-        _write(rows, output, format_)
+        _write(rows, output, format_, fields)
     return len(rows)
 
 
-def _write(rows: Iterable[dict[str, Any]], output: Path, format_: str) -> None:
-    """Write rows in a portable researcher format."""
+def _json_default(value: Any) -> Any:
+    """Preserve numeric precision for Decimal columns; fall back to text for the rest."""
+    if isinstance(value, Decimal):
+        return float(value)
+    return str(value)
+
+
+def _atomic_write(
+    output: Path, mode: str, writer: Callable[[Any], None], **open_kwargs: Any
+) -> None:
+    """Write through a same-directory temp file, then publish with an exclusive, atomic link.
+
+    ``os.link`` fails with ``FileExistsError`` if ``output`` already exists, so two
+    concurrent exports can never both succeed and a partially written file is never
+    visible at the final path.
+    """
+    fd, tmp_name = tempfile.mkstemp(dir=output.parent, prefix=f".{output.name}.")
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, mode, **open_kwargs) as stream:
+            writer(stream)
+        os.link(tmp_path, output)
+    except FileExistsError:
+        raise FileExistsError(f"Refusing to overwrite existing export: {output}") from None
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def _write(
+    rows: Iterable[dict[str, Any]],
+    output: Path,
+    format_: str,
+    fields: Sequence[str] = (),
+) -> None:
+    """Write rows in a portable researcher format, publishing atomically."""
+    if format_ not in _FORMATS:
+        raise ValueError(f"format must be one of: {', '.join(_FORMATS)}")
     materialized = list(rows)
+    fieldnames = list(fields) if fields else (list(materialized[0]) if materialized else [])
     if format_ == "csv":
-        fields = list(materialized[0]) if materialized else []
-        with output.open("x", newline="") as stream:
-            writer = csv.DictWriter(stream, fieldnames=fields)
+
+        def write_csv(stream: Any) -> None:
+            writer = csv.DictWriter(stream, fieldnames=fieldnames)
             writer.writeheader()
             writer.writerows(materialized)
+
+        _atomic_write(output, "w", write_csv, newline="")
         return
     if format_ == "jsonl":
-        with output.open("x") as stream:
+
+        def write_jsonl(stream: Any) -> None:
             for row in materialized:
-                stream.write(json.dumps(row, default=str, sort_keys=True) + "\n")
+                stream.write(json.dumps(row, default=_json_default, sort_keys=True) + "\n")
+
+        _atomic_write(output, "w", write_jsonl)
         return
-    if format_ == "parquet":
-        try:
-            import polars as pl
-        except ImportError as exc:
-            raise RuntimeError("Parquet export requires `uv sync --extra analytics`") from exc
-        pl.DataFrame(materialized).write_parquet(output)
-        return
-    raise ValueError("format must be one of: csv, jsonl, parquet")
+
+    try:
+        import polars as pl
+    except ImportError as exc:
+        raise RuntimeError("Parquet export requires `uv sync --extra analytics`") from exc
+
+    def write_parquet(stream: Any) -> None:
+        pl.DataFrame(materialized).write_parquet(stream)
+
+    _atomic_write(output, "wb", write_parquet)

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,15 +1,28 @@
 """Unit tests for safe researcher-facing export formats."""
 
+from decimal import Decimal
 from pathlib import Path
 
 import pytest
 
-from opendiscourse_research.exports import _write, available_exports, export_relation
+from opendiscourse_research.exports import (
+    EXPORTS,
+    _write,
+    available_exports,
+    export_relation,
+)
 
 
 def test_available_exports_are_named_and_stable() -> None:
     """The public API exposes only reviewed relation names."""
     assert available_exports() == ("measurements",)
+
+
+def test_measurements_export_includes_margin_of_error() -> None:
+    """The named export cannot silently drop a real fact.measurement column."""
+    fields, statement = EXPORTS["measurements"]
+    assert "margin_of_error" in fields
+    assert "margin_of_error" in statement
 
 
 def test_write_csv_and_jsonl(tmp_path: Path) -> None:
@@ -25,6 +38,25 @@ def test_write_csv_and_jsonl(tmp_path: Path) -> None:
     assert jsonl_path.read_text() == '{"dataset_id": "treasury.yield_curve", "value": 4.25}\n'
 
 
+def test_write_csv_empty_result_uses_canonical_header(tmp_path: Path) -> None:
+    """An empty result still yields the reviewed column list, not a blank file."""
+    csv_path = tmp_path / "measurements.csv"
+
+    _write([], csv_path, "csv", fields=("dataset_id", "value"))
+
+    assert csv_path.read_text() == "dataset_id,value\n"
+
+
+def test_write_jsonl_preserves_decimal_precision(tmp_path: Path) -> None:
+    """Numeric columns like value_numeric/margin_of_error stay JSON numbers."""
+    rows = [{"value_numeric": Decimal("4.25"), "margin_of_error": Decimal("0.10")}]
+    jsonl_path = tmp_path / "measurements.jsonl"
+
+    _write(rows, jsonl_path, "jsonl")
+
+    assert jsonl_path.read_text() == '{"margin_of_error": 0.1, "value_numeric": 4.25}\n'
+
+
 def test_export_rejects_unknown_relation_and_existing_output(tmp_path: Path) -> None:
     """Exports cannot execute arbitrary SQL or silently overwrite evidence."""
     with pytest.raises(ValueError, match="Unknown export"):
@@ -34,3 +66,15 @@ def test_export_rejects_unknown_relation_and_existing_output(tmp_path: Path) -> 
     output.write_text("keep")
     with pytest.raises(FileExistsError, match="Refusing to overwrite"):
         export_relation("measurements", output, "csv")
+
+
+def test_export_rejects_unknown_format(tmp_path: Path) -> None:
+    """Format is validated before touching the filesystem or the database."""
+    with pytest.raises(ValueError, match="format must be one of"):
+        export_relation("measurements", tmp_path / "x.tsv", "tsv")
+
+
+def test_write_rejects_unknown_format(tmp_path: Path) -> None:
+    """`_write` enforces the same accepted-format contract as `export_relation`."""
+    with pytest.raises(ValueError, match="format must be one of"):
+        _write([], tmp_path / "x.tsv", "tsv")

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,0 +1,36 @@
+"""Unit tests for safe researcher-facing export formats."""
+
+from pathlib import Path
+
+import pytest
+
+from opendiscourse_research.exports import _write, available_exports, export_relation
+
+
+def test_available_exports_are_named_and_stable() -> None:
+    """The public API exposes only reviewed relation names."""
+    assert available_exports() == ("measurements",)
+
+
+def test_write_csv_and_jsonl(tmp_path: Path) -> None:
+    """Portable formats preserve a small representative research row."""
+    rows = [{"dataset_id": "treasury.yield_curve", "value": 4.25}]
+    csv_path = tmp_path / "measurements.csv"
+    jsonl_path = tmp_path / "measurements.jsonl"
+
+    _write(rows, csv_path, "csv")
+    _write(rows, jsonl_path, "jsonl")
+
+    assert csv_path.read_text() == "dataset_id,value\ntreasury.yield_curve,4.25\n"
+    assert jsonl_path.read_text() == '{"dataset_id": "treasury.yield_curve", "value": 4.25}\n'
+
+
+def test_export_rejects_unknown_relation_and_existing_output(tmp_path: Path) -> None:
+    """Exports cannot execute arbitrary SQL or silently overwrite evidence."""
+    with pytest.raises(ValueError, match="Unknown export"):
+        export_relation("fact.measurement; DROP TABLE fact.measurement", tmp_path / "x.csv", "csv")
+
+    output = tmp_path / "existing.csv"
+    output.write_text("keep")
+    with pytest.raises(FileExistsError, match="Refusing to overwrite"):
+        export_relation("measurements", output, "csv")

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,10 +1,12 @@
 """Unit tests for safe researcher-facing export formats."""
 
+import os
 from decimal import Decimal
 from pathlib import Path
 
 import pytest
 
+from opendiscourse_research import exports
 from opendiscourse_research.exports import (
     EXPORTS,
     _write,
@@ -48,13 +50,63 @@ def test_write_csv_empty_result_uses_canonical_header(tmp_path: Path) -> None:
 
 
 def test_write_jsonl_preserves_decimal_precision(tmp_path: Path) -> None:
-    """Numeric columns like value_numeric/margin_of_error stay JSON numbers."""
-    rows = [{"value_numeric": Decimal("4.25"), "margin_of_error": Decimal("0.10")}]
+    """Numeric columns like value_numeric/margin_of_error stay exact JSON numbers.
+
+    Routing through float would silently drop the trailing zero and, for a
+    long enough coefficient, round the value -- exercised here with more
+    digits than a float's ~15-17 significant digits can carry exactly.
+    """
+    rows = [
+        {
+            "value_numeric": Decimal("4.25"),
+            "margin_of_error": Decimal("0.10"),
+            "value_text": Decimal("123456789012345678901234567890.123456789"),
+        }
+    ]
     jsonl_path = tmp_path / "measurements.jsonl"
 
     _write(rows, jsonl_path, "jsonl")
 
-    assert jsonl_path.read_text() == '{"margin_of_error": 0.1, "value_numeric": 4.25}\n'
+    assert jsonl_path.read_text() == (
+        '{"margin_of_error": 0.10, "value_numeric": 4.25, '
+        '"value_text": 123456789012345678901234567890.123456789}\n'
+    )
+
+
+def test_write_jsonl_rejects_non_finite_decimal(tmp_path: Path) -> None:
+    """NaN/Infinity are valid Decimal values but not valid JSON numbers."""
+    rows = [{"value_numeric": Decimal("NaN")}]
+    jsonl_path = tmp_path / "measurements.jsonl"
+
+    with pytest.raises(ValueError, match="non-finite"):
+        _write(rows, jsonl_path, "jsonl")
+
+    assert not jsonl_path.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_write_does_not_clobber_a_competing_writer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A destination created between the pre-check and publish must not be overwritten.
+
+    ``os.link`` is where the export actually becomes visible; simulate a second
+    process winning that race by creating ``output`` just before the real link.
+    """
+    output = tmp_path / "measurements.csv"
+    real_link = os.link
+
+    def racing_link(src: str, dst: str) -> None:
+        Path(dst).write_text("written by a competing export\n")
+        real_link(src, dst)
+
+    monkeypatch.setattr(exports.os, "link", racing_link)
+
+    with pytest.raises(FileExistsError, match="Refusing to overwrite"):
+        _write([{"a": 1}], output, "csv")
+
+    assert output.read_text() == "written by a competing export\n"
+    assert list(tmp_path.iterdir()) == [output]
 
 
 def test_export_rejects_unknown_relation_and_existing_output(tmp_path: Path) -> None:


### PR DESCRIPTION
## **User description**
Summary: add a named, allow-listed measurement export command with CSV and JSONL support in a base install, optional Parquet support through the existing analytics extra, overwrite protection, and a researcher-facing README example.\n\nValidation: uv run pytest -q tests/test_exports.py; end-to-end CSV export from the live Treasury pilot; uv run alembic check; uv run --locked --extra ingest --extra spatial pytest -q; git diff --check.


___

## **CodeAnt-AI Description**
Add safe exports for reviewed research measurements

### What Changed
- Adds a named `measurements` export command for the canonical measurement data
- Supports CSV and JSONL exports in the base installation, with optional Parquet output through the analytics extra
- Rejects unknown export names and refuses to overwrite existing files
- Documents the export command for researchers

### Impact
`✅ Portable measurement files`
`✅ Protected research evidence from accidental overwrites`
`✅ No arbitrary database queries through exports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
