### PR TITLE
fix: align dbt profile with Docker quickstart

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,9 @@ BLS_API_KEY=
 # connection, so it connects over TCP loopback with this password instead
 # (see dbt/profiles.yml). Not read by the research-db CLI itself.
 DBT_PG_PASSWORD=
+# dbt defaults to the Docker Compose database above. Override all four for
+# bare-metal or shared deployments; export this file before invoking dbt.
+DBT_PG_HOST=127.0.0.1
+DBT_PG_PORT=5433
+DBT_PG_USER=research
+DBT_PG_DBNAME=research

--- a/.env.example
+++ b/.env.example
@@ -24,8 +24,10 @@ BLS_API_KEY=
 # Only needed to run the dbt/ mart-layer project. dbt-fusion's Postgres
 # adapter is experimental and cannot use the app's Unix-socket peer-auth
 # connection, so it connects over TCP loopback with this password instead
-# (see dbt/profiles.yml). Not read by the research-db CLI itself.
-DBT_PG_PASSWORD=
+# (see dbt/profiles.yml). Not read by the research-db CLI itself. Matches
+# POSTGRES_PASSWORD above so the Docker quickstart needs no edits; change
+# both together if you pick a different Docker password.
+DBT_PG_PASSWORD=change-me
 # dbt defaults to the Docker Compose database above. Override all four for
 # bare-metal or shared deployments; export this file before invoking dbt.
 DBT_PG_HOST=127.0.0.1

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -6,17 +6,17 @@
 # this profile uses TCP loopback + scram-sha-256 instead. pg_hba.conf already
 # allowed `host all all 127.0.0.1/32 scram-sha-256`; only the role needed a
 # password (see docs/runtime.md for the auth model this adds to).
-# Set DBT_PG_PASSWORD before running dbt (e.g. in .env, sourced into your
-# shell -- dbt does not read .env files itself).
+# The defaults match compose.yaml. Override DBT_PG_* for bare-metal or a
+# shared deployment; dbt does not read .env files until the shell exports it.
 opendiscourse:
   target: dev
   outputs:
     dev:
       type: postgres
-      host: 127.0.0.1
-      port: 5434
-      user: cbwinslow
-      password: "{{ env_var('DBT_PG_PASSWORD') }}"
-      dbname: opendiscourse
+      host: "{{ env_var('DBT_PG_HOST', '127.0.0.1') }}"
+      port: "{{ env_var('DBT_PG_PORT', '5433') | int }}"
+      user: "{{ env_var('DBT_PG_USER', 'research') }}"
+      password: "{{ env_var('DBT_PG_PASSWORD', 'change-me') }}"
+      dbname: "{{ env_var('DBT_PG_DBNAME', 'research') }}"
       schema: mart
       threads: 4

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -7,7 +7,8 @@
 # allowed `host all all 127.0.0.1/32 scram-sha-256`; only the role needed a
 # password (see docs/runtime.md for the auth model this adds to).
 # The defaults match compose.yaml. Override DBT_PG_* for bare-metal or a
-# shared deployment; dbt does not read .env files until the shell exports it.
+# shared deployment; dbt never reads .env files directly, so export or
+# source them into your shell first.
 opendiscourse:
   target: dev
   outputs:

--- a/docs/mart.md
+++ b/docs/mart.md
@@ -59,9 +59,9 @@ dbt debug --project-dir dbt --profiles-dir dbt   # connection check
 dbt build --project-dir dbt --profiles-dir dbt   # run models + tests
 ```
 
-For Docker Compose, the checked-in profile defaults already match the
-quickstart. Set only `DBT_PG_PASSWORD=change-me` (or the value chosen in
-`POSTGRES_PASSWORD`) before the same commands.
+For Docker Compose, `.env.example`'s defaults already match the checked-in
+profile, so the commands above work unmodified once you've sourced `.env`.
+Only override `DBT_PG_PASSWORD` if you chose a different `POSTGRES_PASSWORD`.
 
 ## What's in it
 

--- a/docs/mart.md
+++ b/docs/mart.md
@@ -25,16 +25,21 @@ Postgres adapter has two rough edges worth knowing before you run it:
    (`src/opendiscourse_research/db.py`) uses peer auth over that socket with
    no password, per `docs/runtime.md` — but dbt needs TCP loopback instead.
 
-   `pg_hba.conf` already allows `host all all 127.0.0.1/32 scram-sha-256`
-   for this cluster, so the only change needed was giving the `cbwinslow`
-   role a password:
+   The checked-in profile defaults to the Docker Compose database. For the
+   bare-metal cluster, `pg_hba.conf` already allows
+   `host all all 127.0.0.1/32 scram-sha-256`; give the `cbwinslow` role a
+   password and override the profile variables:
    ```sql
    ALTER ROLE cbwinslow WITH PASSWORD '...';
    ```
-   `dbt/profiles.yml` connects via `127.0.0.1:5434` with that password
-   pulled from the `DBT_PG_PASSWORD` env var (never written into the
-   profile itself). Add it to `.env` (see `.env.example`) and `source` it,
-   or export it directly — dbt does not read `.env` files on its own.
+   ```bash
+   export DBT_PG_HOST=127.0.0.1 DBT_PG_PORT=5434
+   export DBT_PG_USER=cbwinslow DBT_PG_DBNAME=opendiscourse
+   export DBT_PG_PASSWORD='...'
+   ```
+
+   `dbt` does not read `.env` files on its own, so source or export these
+   variables before running it.
 
 If a future `dbt-fusion` release adds stable, non-experimental Postgres
 support (or Unix-socket support), both workarounds above can be dropped:
@@ -53,6 +58,10 @@ set -a; source .env; set +a   # provides DBT_PG_PASSWORD
 dbt debug --project-dir dbt --profiles-dir dbt   # connection check
 dbt build --project-dir dbt --profiles-dir dbt   # run models + tests
 ```
+
+For Docker Compose, the checked-in profile defaults already match the
+quickstart. Set only `DBT_PG_PASSWORD=change-me` (or the value chosen in
+`POSTGRES_PASSWORD`) before the same commands.
 
 ## What's in it
 


### PR DESCRIPTION
## **User description**
Summary: make the checked-in dbt profile default to the Docker Compose database, add documented DBT_PG_* overrides for bare-metal/shared deployments, and clarify the dbt setup instructions.\n\nValidation: dbt parse with Docker defaults; dbt parse with bare-metal overrides; uv run alembic check; uv run --locked --extra ingest --extra spatial pytest -q; git diff --check.


___

## **CodeAnt-AI Description**
Align dbt setup with Docker defaults and support alternate databases

### What Changed
- dbt now connects to the Docker Compose database by default, including its host, port, user, database, and password defaults
- Bare-metal and shared deployments can override all database connection settings through `DBT_PG_*` variables
- Setup documentation now explains Docker quickstart usage, required password configuration, and overrides for non-Docker databases

### Impact
`✅ Working dbt setup with Docker Compose defaults`
`✅ Easier dbt setup for bare-metal and shared databases`
`✅ Clearer database connection instructions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
